### PR TITLE
Add tool usage logs dashboard and detail views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,8 @@ ehthumbs.db
 # Application specific
 mcp_anywhere.db
 logs/
+!src/mcp_anywhere/web/templates/logs/
+!src/mcp_anywhere/web/templates/logs/*
 *.log
 .cursorrules
 .cursorignore

--- a/src/mcp_anywhere/web/log_routes.py
+++ b/src/mcp_anywhere/web/log_routes.py
@@ -41,7 +41,7 @@ async def tool_usage_dashboard(request: Request) -> Response:
     view_model = _prepare_view_model(logs)
 
     context = get_template_context(request, **view_model)
-    return templates.TemplateResponse("logs/tool_usage.html", context)
+    return templates.TemplateResponse(request, "logs/tool_usage.html", context)
 
 
 async def tool_usage_detail(request: Request) -> Response:
@@ -59,8 +59,9 @@ async def tool_usage_detail(request: Request) -> Response:
 
     detail = _build_detail_view(log_entry)
     return templates.TemplateResponse(
+        request,
         "logs/tool_usage_detail.html",
-        {"request": request, "log": detail},
+        {"log": detail},
     )
 
 
@@ -110,7 +111,7 @@ def _prepare_view_model(logs) -> dict[str, Any]:
             {
                 "date": date_key,
                 "date_label": date_key.strftime("%B %d, %Y"),
-                "items": sorted(items, key=lambda item: item["time"], reverse=True),
+                "entries": sorted(items, key=lambda item: item["time"], reverse=True),
             }
         )
 
@@ -128,6 +129,7 @@ def _prepare_view_model(logs) -> dict[str, Any]:
         "grouped_logs": grouped_logs,
         "summary": summary_list,
         "last_updated": last_updated,
+        "total_count": len(logs),
     }
 
 

--- a/src/mcp_anywhere/web/templates/base.html
+++ b/src/mcp_anywhere/web/templates/base.html
@@ -39,6 +39,9 @@
                     <a href="/" class="text-gray-600 hover:text-gray-900 font-medium transition-colors">
                         Dashboard
                     </a>
+                    <a href="/logs/tools" class="text-gray-600 hover:text-gray-900 font-medium transition-colors">
+                        Usage Logs
+                    </a>
                     <a href="/servers/add" class="btn-primary inline-flex items-center px-4 py-2 rounded-lg transition-colors shadow-md hover:shadow-lg">
                         <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
@@ -107,6 +110,9 @@
                 <div class="space-y-3">
                     <a href="/" class="block text-gray-600 hover:text-gray-900 font-medium transition-colors">
                         Dashboard
+                    </a>
+                    <a href="/logs/tools" class="block text-gray-600 hover:text-gray-900 font-medium transition-colors">
+                        Usage Logs
                     </a>
                     {% if current_user is defined and current_user.is_authenticated %}
                     <button type="button" data-mobile-settings-toggle aria-expanded="false"

--- a/src/mcp_anywhere/web/templates/logs/tool_usage.html
+++ b/src/mcp_anywhere/web/templates/logs/tool_usage.html
@@ -1,0 +1,243 @@
+{% extends "base.html" %}
+
+{% block title %}Tool Usage Analytics{% endblock %}
+
+{% block content %}
+<div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-8">
+    <div>
+        <h1 class="text-3xl font-bold text-gray-900">Tool Usage Analytics</h1>
+        <p class="text-sm text-gray-500 mt-2">
+            Monitor recent MCP tool executions, review success metrics, and inspect detailed payloads.
+        </p>
+    </div>
+    <div class="flex items-center gap-2">
+        <a href="/logs/tools" class="inline-flex items-center px-4 py-2 bg-white border border-gray-200 rounded-lg shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50">
+            <svg class="w-4 h-4 mr-2 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582M20 20v-5h-.581M5 9a7 7 0 0114 0M5 15a7 7 0 0114 0" />
+            </svg>
+            Refresh Data
+        </a>
+        <span class="text-xs text-gray-500">
+            Last updated:
+            {% if last_updated %}
+                {{ last_updated.strftime('%B %d, %Y %H:%M:%S') }}
+            {% else %}
+                Not available
+            {% endif %}
+        </span>
+    </div>
+</div>
+
+{% if summary %}
+<div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 mb-8">
+    {% for item in summary %}
+    <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-5">
+        <div class="flex items-start justify-between mb-3">
+            <div>
+                <p class="text-xs uppercase tracking-wide text-gray-500">{{ item.server_name or 'Unknown Server' }}</p>
+                <h3 class="text-lg font-semibold text-gray-900 mt-1">{{ item.tool_name }}</h3>
+            </div>
+            <span class="inline-flex items-center px-2 py-1 text-xs font-semibold rounded-full bg-blue-50 text-blue-700">
+                {{ item.calls }} calls
+            </span>
+        </div>
+        <dl class="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+            <div>
+                <dt class="text-gray-500">Successes</dt>
+                <dd class="font-medium text-gray-900">{{ item.success }}</dd>
+            </div>
+            <div>
+                <dt class="text-gray-500">Success Rate</dt>
+                <dd class="font-medium text-gray-900">
+                    {% set percentage = (item.success / item.calls * 100) if item.calls else 0 %}
+                    {{ '%.0f' % percentage }}%
+                </dd>
+            </div>
+            <div class="col-span-2">
+                <dt class="text-gray-500">Last Used</dt>
+                <dd class="font-medium text-gray-900">{{ item.last_used.strftime('%B %d, %Y %H:%M:%S') }}</dd>
+            </div>
+        </dl>
+    </div>
+    {% endfor %}
+</div>
+{% endif %}
+
+<div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+    <div class="xl:col-span-2 space-y-6">
+        <section class="bg-white border border-gray-200 rounded-xl shadow-sm">
+            <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+                <h2 class="text-lg font-semibold text-gray-900">Tool Usage Timeline</h2>
+                <span class="text-xs text-gray-500">Grouped by day</span>
+            </div>
+            <div class="divide-y divide-gray-100">
+                {% if grouped_logs %}
+                    {% for group in grouped_logs %}
+                    <div class="px-6 py-4">
+                        <h3 class="text-sm font-semibold text-gray-700 mb-3">{{ group.date_label }}</h3>
+                        <div class="space-y-3">
+                            {% for entry in group.entries %}
+                            <button type="button" onclick="openLogDetail('{{ entry.id }}')"
+                                    class="w-full text-left bg-gray-50 hover:bg-gray-100 transition-colors border border-gray-200 rounded-lg px-4 py-3">
+                                <div class="flex flex-wrap items-center justify-between gap-3">
+                                    <div>
+                                        <p class="text-sm font-semibold text-gray-900 flex items-center gap-2">
+                                            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium
+                                                {% if entry.status.lower() == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">
+                                                {{ entry.status.title() }}
+                                            </span>
+                                            {{ entry.tool_name }}
+                                        </p>
+                                        <p class="text-xs text-gray-500 mt-1">
+                                            {{ entry.time }} • {{ entry.server_name or 'Unknown Server' }} • {{ entry.request_type }}
+                                        </p>
+                                    </div>
+                                    <div class="text-right">
+                                        <p class="text-xs text-gray-500">Client</p>
+                                        <p class="text-sm font-medium text-gray-900">{{ entry.client_name or '—' }}</p>
+                                    </div>
+                                </div>
+                            </button>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    {% endfor %}
+                {% else %}
+                <div class="px-6 py-12 text-center text-gray-500 text-sm">
+                    No tool usage has been recorded yet.
+                </div>
+                {% endif %}
+            </div>
+        </section>
+    </div>
+
+    <section class="bg-white border border-gray-200 rounded-xl shadow-sm">
+        <div class="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+            <h2 class="text-lg font-semibold text-gray-900">Request Logs</h2>
+            <span class="text-xs text-gray-500">Showing {{ total_count }} entries</span>
+        </div>
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 text-sm">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-4 py-3 text-left font-semibold text-gray-600">Timestamp</th>
+                        <th class="px-4 py-3 text-left font-semibold text-gray-600">Client</th>
+                        <th class="px-4 py-3 text-left font-semibold text-gray-600">Server</th>
+                        <th class="px-4 py-3 text-left font-semibold text-gray-600">Request</th>
+                        <th class="px-4 py-3 text-left font-semibold text-gray-600">Status</th>
+                        <th class="px-4 py-3 text-left font-semibold text-gray-600">Processing</th>
+                        <th class="px-4 py-3 text-right font-semibold text-gray-600">Action</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white divide-y divide-gray-100">
+                    {% for group in grouped_logs %}
+                        {% for entry in group.entries %}
+                            <tr class="hover:bg-gray-50">
+                                <td class="px-4 py-3 whitespace-nowrap text-gray-900">{{ entry.timestamp_iso }}</td>
+                                <td class="px-4 py-3 whitespace-nowrap text-gray-600">{{ entry.client_name or '—' }}</td>
+                                <td class="px-4 py-3 whitespace-nowrap text-gray-600">{{ entry.server_name or '—' }}</td>
+                                <td class="px-4 py-3 whitespace-nowrap text-gray-600">{{ entry.request_type }}</td>
+                                <td class="px-4 py-3 whitespace-nowrap">
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium
+                                        {% if entry.status.lower() == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">
+                                        {{ entry.status.title() }}
+                                    </span>
+                                </td>
+                                <td class="px-4 py-3 whitespace-nowrap text-gray-600">
+                                    {% if entry.processing_ms is not none %}
+                                        {{ entry.processing_ms }} ms
+                                    {% else %}
+                                        —
+                                    {% endif %}
+                                </td>
+                                <td class="px-4 py-3 whitespace-nowrap text-right">
+                                    <button type="button" onclick="openLogDetail('{{ entry.id }}')"
+                                            class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded-lg text-xs font-medium text-gray-700 hover:bg-gray-50">
+                                        View
+                                    </button>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    {% endfor %}
+                    {% if total_count == 0 %}
+                    <tr>
+                        <td colspan="7" class="px-4 py-6 text-center text-sm text-gray-500">No recent requests recorded.</td>
+                    </tr>
+                    {% endif %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+</div>
+
+<div id="log-detail-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-gray-900 bg-opacity-60">
+    <div class="w-full max-w-4xl mx-4" id="log-detail-content">
+        <!-- Detail content injected dynamically -->
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script>
+    const modal = document.getElementById('log-detail-modal');
+    const contentContainer = document.getElementById('log-detail-content');
+
+    function closeLogDetail() {
+        modal.classList.add('hidden');
+        contentContainer.innerHTML = '';
+    }
+
+    async function openLogDetail(logId) {
+        if (!modal || !contentContainer) {
+            return;
+        }
+        modal.classList.remove('hidden');
+        contentContainer.innerHTML = '<div class="bg-white rounded-xl shadow-lg p-8 text-center text-gray-500">Loading log details...</div>';
+
+        try {
+            const response = await fetch(`/logs/tools/${logId}`);
+            if (!response.ok) {
+                throw new Error(`Failed to fetch log detail: ${response.status}`);
+            }
+            const html = await response.text();
+            contentContainer.innerHTML = html;
+        } catch (error) {
+            console.error(error);
+            contentContainer.innerHTML = '<div class="bg-white rounded-xl shadow-lg p-6 text-center text-red-600">Unable to load log details. Please try again later.</div>';
+        }
+    }
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !modal.classList.contains('hidden')) {
+            closeLogDetail();
+        }
+    });
+
+    document.addEventListener('click', (event) => {
+        if (event.target === modal) {
+            closeLogDetail();
+        }
+    });
+
+    document.addEventListener('click', (event) => {
+        const target = event.target.closest('[data-copy-target]');
+        if (!target) {
+            return;
+        }
+        const elementId = target.getAttribute('data-copy-target');
+        const textElement = document.getElementById(elementId);
+        if (!textElement) {
+            return;
+        }
+        copyToClipboard(textElement.innerText);
+        target.innerText = 'Copied!';
+        setTimeout(() => {
+            target.innerText = 'Copy';
+        }, 2000);
+    });
+
+    window.openLogDetail = openLogDetail;
+    window.closeLogDetail = closeLogDetail;
+</script>
+{% endblock %}

--- a/src/mcp_anywhere/web/templates/logs/tool_usage_detail.html
+++ b/src/mcp_anywhere/web/templates/logs/tool_usage_detail.html
@@ -1,0 +1,80 @@
+<div class="bg-white rounded-2xl shadow-2xl border border-gray-200">
+    <div class="flex items-start justify-between px-6 py-5 border-b border-gray-200">
+        <div>
+            <p class="text-xs uppercase tracking-wide text-gray-500">{{ log.request_type }}</p>
+            <h2 class="text-2xl font-semibold text-gray-900">{{ log.full_tool_name }}</h2>
+            <p class="text-sm text-gray-500 mt-1">{{ log.timestamp }}</p>
+        </div>
+        <div class="flex items-center gap-2">
+            <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium
+                {% if log.status.lower() == 'success' %}bg-green-100 text-green-700{% else %}bg-red-100 text-red-700{% endif %}">
+                {{ log.status.title() }}
+            </span>
+            <button type="button" onclick="closeLogDetail()"
+                    class="inline-flex items-center justify-center w-9 h-9 rounded-full bg-gray-100 text-gray-600 hover:bg-gray-200">
+                <span class="sr-only">Close</span>
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </button>
+        </div>
+    </div>
+
+    <div class="px-6 py-5 space-y-6">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <dl class="bg-gray-50 rounded-lg p-4 space-y-1">
+                <dt class="text-xs uppercase text-gray-500">Server</dt>
+                <dd class="text-sm font-medium text-gray-900">{{ log.server_name or 'Unknown server' }}</dd>
+            </dl>
+            <dl class="bg-gray-50 rounded-lg p-4 space-y-1">
+                <dt class="text-xs uppercase text-gray-500">Client</dt>
+                <dd class="text-sm font-medium text-gray-900">{{ log.client_name or 'Not available' }}</dd>
+            </dl>
+            <dl class="bg-gray-50 rounded-lg p-4 space-y-1">
+                <dt class="text-xs uppercase text-gray-500">Processing Time</dt>
+                <dd class="text-sm font-medium text-gray-900">
+                    {% if log.processing_ms is not none %}
+                        {{ log.processing_ms }} ms
+                    {% else %}
+                        Not captured
+                    {% endif %}
+                </dd>
+            </dl>
+            <dl class="bg-gray-50 rounded-lg p-4 space-y-1">
+                <dt class="text-xs uppercase text-gray-500">Log ID</dt>
+                <dd class="text-xs font-mono text-gray-700 break-all">{{ log.id }}</dd>
+            </dl>
+        </div>
+
+        <section>
+            <div class="flex items-center justify-between mb-2">
+                <h3 class="text-sm font-semibold text-gray-900">Request Parameters</h3>
+                <button type="button" data-copy-target="log-request-json"
+                        class="text-xs font-medium text-blue-600 hover:text-blue-700">Copy</button>
+            </div>
+            <pre id="log-request-json" class="bg-gray-900 text-gray-100 text-xs rounded-lg p-4 overflow-x-auto">{{ log.arguments_json | e }}</pre>
+        </section>
+
+        <section>
+            <div class="flex items-center justify-between mb-2">
+                <h3 class="text-sm font-semibold text-gray-900">Response Data</h3>
+                <button type="button" data-copy-target="log-response-json"
+                        class="text-xs font-medium text-blue-600 hover:text-blue-700">Copy</button>
+            </div>
+            <pre id="log-response-json" class="bg-gray-900 text-gray-100 text-xs rounded-lg p-4 overflow-x-auto">{{ log.response_json | e }}</pre>
+        </section>
+
+        <section>
+            <h3 class="text-sm font-semibold text-gray-900 mb-2">Error Message</h3>
+            {% if log.error_message %}
+                <div class="bg-red-50 border border-red-200 text-red-700 text-sm rounded-lg p-4">
+                    {{ log.error_message }}
+                </div>
+            {% else %}
+                <div class="bg-gray-50 border border-gray-200 text-gray-600 text-sm rounded-lg p-4">
+                    No error information recorded.
+                </div>
+            {% endif %}
+        </section>
+    </div>
+</div>

--- a/tests/test_tool_usage_routes.py
+++ b/tests/test_tool_usage_routes.py
@@ -1,0 +1,82 @@
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+from sqlalchemy import select
+
+from mcp_anywhere.auth.models import User
+from mcp_anywhere.database import ToolUsageLog
+
+
+async def _set_admin_password(app, password: str) -> None:
+    async with app.state.get_async_session() as session:
+        stmt = select(User).where(User.username == "admin")
+        user = await session.scalar(stmt)
+        assert user is not None
+        user.set_password(password)
+        session.add(user)
+        await session.commit()
+
+
+async def _login(client: httpx.AsyncClient, username: str, password: str) -> httpx.Response:
+    return await client.post(
+        "/auth/login",
+        data={"username": username, "password": password},
+        follow_redirects=False,
+    )
+
+
+async def _create_tool_log(app) -> ToolUsageLog:
+    async with app.state.get_async_session() as session:
+        log = ToolUsageLog(
+            timestamp=datetime.now(timezone.utc).replace(tzinfo=None),
+            client_name="test-client",
+            request_type="CallTool",
+            server_id="srv",
+            server_name="Test Server",
+            tool_name="sample",
+            full_tool_name="srv_sample",
+            status="success",
+            processing_ms=2187,
+            arguments={"foo": "bar"},
+            response={"content": []},
+            error_message=None,
+        )
+        session.add(log)
+        await session.commit()
+        await session.refresh(log)
+        return log
+
+
+@pytest.mark.asyncio
+async def test_tool_usage_dashboard_requires_auth(client: httpx.AsyncClient) -> None:
+    response = await client.get("/logs/tools", follow_redirects=False)
+    assert response.status_code == 302
+    assert "/auth/login" in response.headers.get("location", "")
+
+
+@pytest.mark.asyncio
+async def test_tool_usage_detail_requires_auth(client: httpx.AsyncClient) -> None:
+    response = await client.get("/logs/tools/some-id", follow_redirects=False)
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_tool_usage_dashboard_renders_with_logs(app) -> None:
+    await _set_admin_password(app, "Password123!")
+    log = await _create_tool_log(app)
+
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as authed_client:
+        login_response = await _login(authed_client, "admin", "Password123!")
+        assert login_response.status_code == 302
+
+        page = await authed_client.get("/logs/tools")
+        assert page.status_code == 200
+        assert "Tool Usage Analytics" in page.text
+        assert "Test Server" in page.text
+        assert "sample" in page.text
+
+        detail = await authed_client.get(f"/logs/tools/{log.id}")
+        assert detail.status_code == 200
+        assert "Request Parameters" in detail.text
+        assert "foo" in detail.text


### PR DESCRIPTION
## Summary
- add Jinja templates for the tool usage dashboard and detailed log viewer with navigation entry
- update log routes view model and rendering to support new template structure and total counts
- add regression tests for the tool usage routes and allow committing templates under logs/

## Testing
- `uv run python -m pytest tests/test_tool_usage_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68cdced76578832eb97462d25c1e6dab