### PR TITLE
Implement server toggles and fix MCP tool listing

### DIFF
--- a/src/mcp_anywhere/container/manager.py
+++ b/src/mcp_anywhere/container/manager.py
@@ -755,6 +755,12 @@ class ContainerManager:
 
             async with get_async_session() as db_session:
                 for server in built_servers:
+                    if not server.is_active:
+                        logger.debug(
+                            f"Skipping mount for inactive server '{server.name}'"
+                        )
+                        continue
+
                     container_name = self._get_container_name(server.id)
                     if container_name in self.reused_containers:
                         logger.debug(

--- a/src/mcp_anywhere/web/templates/index.html
+++ b/src/mcp_anywhere/web/templates/index.html
@@ -113,18 +113,19 @@
                 <p class="text-sm text-gray-600 mb-3 h-12 leading-4">&nbsp;</p>
                 {% endif %}
                 
-                <div class="flex flex-wrap gap-2 mb-3">
-                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium 
-                        {% if server.is_active %}bg-green-100 text-green-800{% else %}bg-red-100 text-red-800{% endif %}">
-                        {% if server.is_active %}Active{% else %}Inactive{% endif %}
-                    </span>
-                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
-                        {% if server.build_status == 'built' %}bg-blue-100 text-blue-800{% elif server.build_status == 'building' %}bg-yellow-100 text-yellow-800{% else %}bg-red-100 text-red-800{% endif %}">
-                        {{ server.build_status.title() }}
-                    </span>
-                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
-                        {{ server.tools|length }} tools
-                    </span>
+                <div class="flex items-start justify-between gap-3 mb-3">
+                    <div class="flex flex-wrap gap-2">
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
+                            {% if server.build_status == 'built' %}bg-blue-100 text-blue-800{% elif server.build_status == 'building' %}bg-yellow-100 text-yellow-800{% else %}bg-red-100 text-red-800{% endif %}">
+                            {{ server.build_status.title() }}
+                        </span>
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+                            {{ server.tools|length }} tools
+                        </span>
+                    </div>
+                    <div class="min-w-[120px]">
+                        {% include "partials/server_toggle.html" with server=server, layout='card', redirect_to='/' %}
+                    </div>
                 </div>
                 
                 <div class="text-xs text-gray-500 space-y-1">

--- a/src/mcp_anywhere/web/templates/partials/server_toggle.html
+++ b/src/mcp_anywhere/web/templates/partials/server_toggle.html
@@ -1,0 +1,25 @@
+{% set layout = layout or 'default' %}
+{% set active = server.is_active %}
+<div class="{% if layout == 'card' %}flex items-center justify-between gap-3{% else %}flex items-center justify-between gap-4{% endif %}"
+     id="server-status-toggle-{{ server.id }}">
+    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {% if active %}bg-green-100 text-green-800{% else %}bg-red-100 text-red-800{% endif %}">
+        {% if active %}Active{% else %}Inactive{% endif %}
+    </span>
+    <form hx-post="/servers/{{ server.id }}/toggle"
+          hx-target="#server-status-toggle-{{ server.id }}"
+          hx-swap="outerHTML"
+          class="flex items-center">
+        <input type="hidden" name="redirect_to" value="{{ redirect_to or request.url.path }}">
+        <input type="hidden" name="layout" value="{{ layout }}">
+        <button type="submit"
+                class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 {% if active %}bg-green-500{% else %}bg-gray-300{% endif %}"
+                aria-pressed="{{ 'true' if active else 'false' }}"
+                aria-label="Toggle server {{ server.name }}">
+            <span class="sr-only">Toggle server {{ server.name }}</span>
+            <span class="inline-block h-5 w-5 transform rounded-full bg-white shadow transition duration-200 {% if active %}translate-x-5{% else %}translate-x-1{% endif %}"></span>
+        </button>
+    </form>
+</div>
+{% if toggle_error %}
+    <p class="mt-2 text-xs text-red-600">{{ toggle_error }}</p>
+{% endif %}

--- a/src/mcp_anywhere/web/templates/servers/detail.html
+++ b/src/mcp_anywhere/web/templates/servers/detail.html
@@ -49,12 +49,11 @@
         <div class="bg-white rounded-lg shadow p-6">
             <h3 class="text-lg font-semibold mb-4">Status</h3>
             <div class="space-y-3">
-                <div class="flex justify-between items-center">
+                <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
                     <span class="text-gray-600">Server Status:</span>
-                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium 
-                        {% if server.is_active %}bg-green-100 text-green-800{% else %}bg-red-100 text-red-800{% endif %}">
-                        {% if server.is_active %}Active{% else %}Inactive{% endif %}
-                    </span>
+                    <div class="sm:ml-4">
+                        {% include "partials/server_toggle.html" with server=server, layout='detail', redirect_to='/servers/' ~ server.id %}
+                    </div>
                 </div>
                 <div class="flex justify-between items-center">
                     <span class="text-gray-600">Build Status:</span>

--- a/tests/test_server_toggle_route.py
+++ b/tests/test_server_toggle_route.py
@@ -1,0 +1,76 @@
+"""Tests for server activation toggle route."""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from mcp_anywhere.auth.models import User
+from mcp_anywhere.database import MCPServer, get_async_session
+
+
+async def _set_admin_password(app, password: str) -> None:
+    """Ensure the admin user has a known password for authentication."""
+
+    async with app.state.get_async_session() as session:
+        stmt = select(User).where(User.username == "admin")
+        user = await session.scalar(stmt)
+        assert user is not None
+        user.set_password(password)
+        session.add(user)
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_toggle_server_route_updates_activation_state(app, client):
+    """The toggle route should flip the server's is_active flag."""
+
+    await _set_admin_password(app, "TogglePass123!")
+
+    login_response = await client.post(
+        "/auth/login",
+        data={"username": "admin", "password": "TogglePass123!"},
+        follow_redirects=False,
+    )
+    assert login_response.status_code == 302
+    assert login_response.headers.get("location") == "/"
+
+    async with get_async_session() as session:
+        server = MCPServer(
+            name=f"Toggle Server {uuid.uuid4().hex[:6]}",
+            github_url="https://github.com/example/toggle-server",
+            description="Toggle test server",
+            runtime_type="docker",
+            install_command="",
+            start_command="npm run start",
+            is_active=True,
+        )
+        session.add(server)
+        await session.commit()
+        await session.refresh(server)
+        server_id = server.id
+
+    response = await client.post(
+        f"/servers/{server_id}/toggle",
+        data={"redirect_to": "/"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["location"] == "/"
+
+    async with get_async_session() as session:
+        refreshed = await session.get(MCPServer, server_id)
+        assert refreshed is not None
+        assert refreshed.is_active is False
+
+    response = await client.post(
+        f"/servers/{server_id}/toggle",
+        data={"redirect_to": "/"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+    async with get_async_session() as session:
+        refreshed = await session.get(MCPServer, server_id)
+        assert refreshed is not None
+        assert refreshed.is_active is True


### PR DESCRIPTION
## Summary
- ensure the tool-filtering middleware preserves all registered tools when listing
- add a UI toggle and route to activate or deactivate MCP servers and keep mounts in sync
- update the dashboard and detail pages with the new toggle component and supporting tests

## Testing
- `uv run python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ce0f339950832e9e3b3913ed1891c1