### PR TITLE
Fix Jinja include syntax for server toggle

### DIFF
--- a/src/mcp_anywhere/web/templates/index.html
+++ b/src/mcp_anywhere/web/templates/index.html
@@ -124,7 +124,9 @@
                         </span>
                     </div>
                     <div class="min-w-[120px]">
-                        {% include "partials/server_toggle.html" with server=server, layout='card', redirect_to='/' %}
+                        {% with server=server, layout='card', redirect_to='/' %}
+                            {% include "partials/server_toggle.html" %}
+                        {% endwith %}
                     </div>
                 </div>
                 


### PR DESCRIPTION
## Summary
- wrap the server toggle include in a Jinja `{% with %}` block so the template compiles on homepage

## Testing
- uv run pytest tests/test_web_app.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ce12a9a054832ea6caccaa96f97896