### PR TITLE
Fix server detail include syntax for Jinja

### DIFF
--- a/src/mcp_anywhere/web/templates/servers/detail.html
+++ b/src/mcp_anywhere/web/templates/servers/detail.html
@@ -52,7 +52,9 @@
                 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
                     <span class="text-gray-600">Server Status:</span>
                     <div class="sm:ml-4">
-                        {% include "partials/server_toggle.html" with server=server, layout='detail', redirect_to='/servers/' ~ server.id %}
+                        {% with layout='detail', redirect_to='/servers/' ~ server.id %}
+                            {% include "partials/server_toggle.html" %}
+                        {% endwith %}
                     </div>
                 </div>
                 <div class="flex justify-between items-center">


### PR DESCRIPTION
## Summary
- wrap the server status toggle include in a Jinja `with` block so additional context variables can be set without using unsupported syntax

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1bda81318832eba88a2dc63a82e76