### PR TITLE
Add CLI command to reset admin password

### DIFF
--- a/tests/test_admin_reset_password_cli.py
+++ b/tests/test_admin_reset_password_cli.py
@@ -1,0 +1,60 @@
+import pytest
+from sqlalchemy import select
+
+from mcp_anywhere.auth.initialization import reset_user_password
+from mcp_anywhere.auth.models import User
+
+
+@pytest.mark.asyncio
+async def test_reset_user_password_updates_hash(app):
+    """Resetting the password should update the stored hash for the user."""
+
+    async with app.state.get_async_session() as session:
+        admin = await session.scalar(select(User).where(User.username == "admin"))
+        assert admin is not None
+        admin.set_password("OriginalPassword123!")
+        session.add(admin)
+        await session.commit()
+
+    await reset_user_password("admin", "BrandNewPassword123!")
+
+    async with app.state.get_async_session() as session:
+        admin = await session.scalar(select(User).where(User.username == "admin"))
+        assert admin is not None
+        assert admin.check_password("BrandNewPassword123!")
+
+
+@pytest.mark.asyncio
+async def test_reset_user_password_missing_user_raises(app):
+    """Attempting to reset a missing user should raise a ValueError."""
+
+    # Ensure the target username does not exist
+    async with app.state.get_async_session() as session:
+        ghost = await session.scalar(select(User).where(User.username == "ghost"))
+        if ghost is not None:
+            await session.delete(ghost)
+            await session.commit()
+
+    with pytest.raises(ValueError, match="ghost"):
+        await reset_user_password("ghost", "ValidPassword123!")
+
+
+@pytest.mark.asyncio
+async def test_reset_user_password_enforces_min_length(app):
+    """Passwords shorter than the policy should be rejected."""
+
+    async with app.state.get_async_session() as session:
+        admin = await session.scalar(select(User).where(User.username == "admin"))
+        assert admin is not None
+        admin.set_password("KeepOldPassword123!")
+        session.add(admin)
+        await session.commit()
+
+    with pytest.raises(ValueError, match="at least 12 characters"):
+        await reset_user_password("admin", "shortpwd")
+
+    # Confirm the password is unchanged
+    async with app.state.get_async_session() as session:
+        admin = await session.scalar(select(User).where(User.username == "admin"))
+        assert admin is not None
+        assert admin.check_password("KeepOldPassword123!")


### PR DESCRIPTION
## Summary
- add an `admin reset-password` CLI command with interactive prompting and optional password argument
- implement a reusable `reset_user_password` helper that enforces password policy before updating the database
- cover the new helper with tests for success, missing users, and policy validation failures

## Testing
- uv run pytest tests/test_admin_reset_password_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d1fbc810d4832e990a61669ef3139d