### PR TITLE
Ensure admin password reset CLI bootstraps database

### DIFF
--- a/src/mcp_anywhere/__main__.py
+++ b/src/mcp_anywhere/__main__.py
@@ -6,13 +6,15 @@ including HTTP server, STDIO server, and client connection modes.
 
 import argparse
 import asyncio
+import getpass
 import shutil
 import signal
 import sys
 
+from mcp_anywhere.auth.initialization import initialize_oauth_data, reset_user_password
 from mcp_anywhere.config import Config
 from mcp_anywhere.container.manager import ContainerManager
-from mcp_anywhere.database import close_db
+from mcp_anywhere.database import close_db, init_db
 from mcp_anywhere.logging_config import get_logger
 from mcp_anywhere.transport.http_server import run_http_server
 from mcp_anywhere.transport.stdio_gateway import run_connect_gateway
@@ -124,6 +126,29 @@ def create_parser() -> argparse.ArgumentParser:
         "--confirm", action="store_true", help="Skip confirmation prompt"
     )
 
+    # Admin command group
+    admin_parser = subparsers.add_parser(
+        "admin", help="Administrative utilities"
+    )
+    admin_subparsers = admin_parser.add_subparsers(
+        dest="admin_command", required=True, help="Admin operations"
+    )
+
+    reset_password_parser = admin_subparsers.add_parser(
+        "reset-password", help="Reset the password for an existing user"
+    )
+    reset_password_parser.add_argument(
+        "--username",
+        type=str,
+        default="admin",
+        help="Username to reset (default: admin)",
+    )
+    reset_password_parser.add_argument(
+        "--password",
+        type=str,
+        help="New password to set. If omitted, the CLI will prompt interactively.",
+    )
+
     return parser
 
 
@@ -172,6 +197,24 @@ def reset_data(confirm: bool = False) -> None:
         sys.exit(1)
 
 
+def prompt_for_password(min_length: int = 12) -> str:
+    """Prompt the user for a password with confirmation."""
+
+    while True:
+        password = getpass.getpass("New password: ")
+        confirm = getpass.getpass("Confirm new password: ")
+
+        if password != confirm:
+            print("Passwords do not match. Please try again.")
+            continue
+
+        if len(password) < min_length:
+            print(f"Password must be at least {min_length} characters long.")
+            continue
+
+        return password
+
+
 async def main() -> None:
     """Main entry point for MCP Anywhere application.
 
@@ -187,6 +230,24 @@ async def main() -> None:
         if args.command == "reset":
             reset_data(confirm=args.confirm)
             return
+
+        if args.command == "admin":
+            if args.admin_command == "reset-password":
+                password = args.password or prompt_for_password()
+                try:
+                    await init_db()
+                    if args.username == "admin":
+                        await initialize_oauth_data()
+                    await reset_user_password(args.username, password)
+                except ValueError as exc:
+                    print(f"Error: {exc}", file=sys.stderr)
+                    sys.exit(1)
+                except RuntimeError as exc:
+                    print(f"Error: {exc}", file=sys.stderr)
+                    sys.exit(1)
+
+                print(f"Password updated for user '{args.username}'.")
+                return
 
         # Setup signal handlers for graceful shutdown (only for server modes)
         if args.command == "serve":

--- a/tests/test_admin_reset_password_cli.py
+++ b/tests/test_admin_reset_password_cli.py
@@ -1,0 +1,111 @@
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from werkzeug.security import check_password_hash
+
+from mcp_anywhere.auth.initialization import reset_user_password
+from mcp_anywhere.auth.models import User
+
+
+@pytest.mark.asyncio
+async def test_reset_user_password_updates_hash(app):
+    """Resetting the password should update the stored hash for the user."""
+
+    async with app.state.get_async_session() as session:
+        admin = await session.scalar(select(User).where(User.username == "admin"))
+        assert admin is not None
+        admin.set_password("OriginalPassword123!")
+        session.add(admin)
+        await session.commit()
+
+    await reset_user_password("admin", "BrandNewPassword123!")
+
+    async with app.state.get_async_session() as session:
+        admin = await session.scalar(select(User).where(User.username == "admin"))
+        assert admin is not None
+        assert admin.check_password("BrandNewPassword123!")
+
+
+@pytest.mark.asyncio
+async def test_reset_user_password_missing_user_raises(app):
+    """Attempting to reset a missing user should raise a ValueError."""
+
+    # Ensure the target username does not exist
+    async with app.state.get_async_session() as session:
+        ghost = await session.scalar(select(User).where(User.username == "ghost"))
+        if ghost is not None:
+            await session.delete(ghost)
+            await session.commit()
+
+    with pytest.raises(ValueError, match="ghost"):
+        await reset_user_password("ghost", "ValidPassword123!")
+
+
+@pytest.mark.asyncio
+async def test_reset_user_password_enforces_min_length(app):
+    """Passwords shorter than the policy should be rejected."""
+
+    async with app.state.get_async_session() as session:
+        admin = await session.scalar(select(User).where(User.username == "admin"))
+        assert admin is not None
+        admin.set_password("KeepOldPassword123!")
+        session.add(admin)
+        await session.commit()
+
+    with pytest.raises(ValueError, match="at least 12 characters"):
+        await reset_user_password("admin", "shortpwd")
+
+    # Confirm the password is unchanged
+    async with app.state.get_async_session() as session:
+        admin = await session.scalar(select(User).where(User.username == "admin"))
+        assert admin is not None
+        assert admin.check_password("KeepOldPassword123!")
+
+
+def test_cli_reset_password_bootstraps_database(tmp_path):
+    """The CLI should initialize the database before resetting the password."""
+
+    data_dir = tmp_path / "data"
+    env = os.environ.copy()
+    env.pop("PYTEST_CURRENT_TEST", None)
+
+    pythonpath_entries = [str(Path(__file__).resolve().parents[1] / "src")]
+    if env.get("PYTHONPATH"):
+        pythonpath_entries.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+    env["DATA_DIR"] = str(data_dir)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mcp_anywhere.__main__",
+            "admin",
+            "reset-password",
+            "--password",
+            "AdminSecret123!",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert "Password updated for user 'admin'." in result.stdout
+
+    db_path = data_dir / "mcp_anywhere.db"
+    assert db_path.exists(), "CLI should create the sqlite database file"
+
+    with sqlite3.connect(db_path) as connection:
+        row = connection.execute(
+            "SELECT password_hash FROM users WHERE username = ?",
+            ("admin",),
+        ).fetchone()
+
+    assert row is not None, "Admin user should be present after CLI reset"
+    assert check_password_hash(row[0], "AdminSecret123!")


### PR DESCRIPTION
## Summary
- initialize the database and seed default admin data before running the reset-password CLI flow
- add error handling for initialization failures to surface helpful CLI feedback
- add a regression test exercising the CLI against an empty DATA_DIR and verifying the password hash

## Testing
- uv run pytest tests/test_admin_reset_password_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68d1fbc810d4832e990a61669ef3139d