### PR TITLE
Improve Claude analyzer parsing robustness

### DIFF
--- a/src/mcp_anywhere/server_guidance.py
+++ b/src/mcp_anywhere/server_guidance.py
@@ -12,8 +12,10 @@ CONTAINER_EXECUTION_NOTE = (
 
 RUNTIME_GUIDANCE = dedent(
     """
-    Determine if this is 'npx' (for Node.js) or 'uvx' (for Python). Prioritize `pyproject.toml`
-    for Python projects and `package.json` for Node.js projects.
+    Determine the correct runtime:
+    - Use 'uvx' for Python projects (look for `pyproject.toml`).
+    - Use 'npx' for Node.js projects (look for `package.json`).
+    - Use 'docker' only when the repository must be built/run via Docker.
     """
 ).strip()
 

--- a/tests/test_claude_analyzer.py
+++ b/tests/test_claude_analyzer.py
@@ -210,6 +210,34 @@ ENV_VARS:
 
 
 @pytest.mark.asyncio
+async def test_parse_claude_response_handles_variations():
+    """Ensure parsing tolerates lowercase labels and optional install markers."""
+
+    response_text = """runtime: Docker image build
+install: `none required.`
+start: docker run my-image
+name: Example Docker Server
+description: Runs the MCP server from a Docker image
+env_vars:
+• key: API_KEY, desc: API token, required: YES
+- key: DEBUG_MODE, desc: Enable verbose logging, required: no"""
+
+    analyzer = AsyncClaudeAnalyzer.__new__(AsyncClaudeAnalyzer)
+    result = analyzer._parse_claude_response(response_text)
+
+    assert result["runtime_type"] == "docker"
+    assert result["install_command"] == ""
+    assert result["start_command"] == "docker run my-image"
+    assert result["name"] == "Example Docker Server"
+    assert result["description"] == "Runs the MCP server from a Docker image"
+    assert len(result["env_variables"]) == 2
+    assert result["env_variables"][0]["key"] == "API_KEY"
+    assert result["env_variables"][0]["required"] is True
+    assert result["env_variables"][1]["key"] == "DEBUG_MODE"
+    assert result["env_variables"][1]["required"] is False
+
+
+@pytest.mark.asyncio
 async def test_call_claude_api_success(analyzer):
     """Test successful Claude API call."""
 


### PR DESCRIPTION
## Summary
- normalize Claude analyzer parsing to accept varied label casing, optional install text, and bullet styles
- update runtime guidance and prompt instructions to cover docker and enforce uppercase labels
- add regression coverage ensuring parsing handles these variations

## Testing
- uv run python -m pytest tests/test_claude_analyzer.py

------
https://chatgpt.com/codex/tasks/task_e_68d2038f5a94832e880c71f55eaa5ef9