### PR TITLE
Fix server detail template include syntax

### DIFF
--- a/src/mcp_anywhere/web/templates/servers/detail.html
+++ b/src/mcp_anywhere/web/templates/servers/detail.html
@@ -413,7 +413,10 @@
                     </div>
                 </form>
                 <div id="tool-test-result-{{ tool.id }}" class="mt-4">
-                    {% include 'partials/tool_test_result.html' with status='idle', tool=tool only %}
+                    {% with %}
+                        {% set status = 'idle' %}
+                        {% include 'partials/tool_test_result.html' %}
+                    {% endwith %}
                 </div>
                 {% else %}
                 <div class="mt-4 rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">


### PR DESCRIPTION
## Summary
- fix the Jinja include block in the server detail template so the tool test result partial renders with a default idle status

## Testing
- not run (template-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e5894a6974832e8079126d05ebf931