### PR TITLE
Handle MCP tool metadata timeouts and cache schemas

### DIFF
--- a/src/mcp_anywhere/database_utils.py
+++ b/src/mcp_anywhere/database_utils.py
@@ -40,17 +40,30 @@ async def store_server_tools(
 
         # Add new tools
         for tool_name in tools_to_add:
+            tool_data = discovered_tools_dict[tool_name]
             new_tool = MCPServerTool(
                 server_id=server_config.id,
                 tool_name=tool_name,
-                tool_description=discovered_tools_dict[tool_name]["description"],
+                tool_description=tool_data.get("description"),
                 is_enabled=True,
             )
+            if "schema" in tool_data:
+                new_tool.tool_schema = tool_data["schema"]
             db_session.add(new_tool)
 
         logger.info(
             f"Added {len(tools_to_add)} tools for server '{server_config.name}'"
         )
+
+        # Update existing tools with refreshed metadata
+        for tool_name, existing_tool in existing_tools.items():
+            if tool_name not in discovered_tools_dict:
+                continue
+
+            tool_data = discovered_tools_dict[tool_name]
+            existing_tool.tool_description = tool_data.get("description")
+            if "schema" in tool_data:
+                existing_tool.tool_schema = tool_data["schema"]
 
         # Remove tools that are no longer present
         if tools_to_remove:

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -1,0 +1,88 @@
+import pytest
+from sqlalchemy import select
+
+from mcp_anywhere.database import MCPServer, MCPServerTool
+from mcp_anywhere.database_utils import store_server_tools
+
+
+@pytest.mark.asyncio
+async def test_store_server_tools_persists_schema(db_session):
+    server = MCPServer(
+        name="Server With Schema",
+        github_url="https://example.com/repo.git",
+        runtime_type="docker",
+        install_command="pip install -r requirements.txt",
+        start_command="uv run start",
+        env_variables=[],
+    )
+    db_session.add(server)
+    await db_session.commit()
+
+    schema = {"type": "object", "properties": {"foo": {"type": "string"}}}
+
+    await store_server_tools(
+        db_session,
+        server,
+        [
+            {
+                "name": "server.tool/foo",
+                "description": "Example tool",
+                "schema": schema,
+            }
+        ],
+    )
+
+    result = await db_session.execute(select(MCPServerTool))
+    tool = result.scalar_one()
+    assert tool.tool_schema == schema
+
+
+@pytest.mark.asyncio
+async def test_store_server_tools_updates_schema(db_session):
+    server = MCPServer(
+        name="Server Update Schema",
+        github_url="https://example.com/repo.git",
+        runtime_type="docker",
+        install_command="pip install -r requirements.txt",
+        start_command="uv run start",
+        env_variables=[],
+    )
+    db_session.add(server)
+    await db_session.commit()
+
+    original_schema = {"type": "object", "properties": {}}
+    updated_schema = {
+        "type": "object",
+        "properties": {"bar": {"type": "integer"}},
+    }
+
+    await store_server_tools(
+        db_session,
+        server,
+        [
+            {
+                "name": "server.tool/bar",
+                "description": "Tool",
+                "schema": original_schema,
+            }
+        ],
+    )
+
+    await store_server_tools(
+        db_session,
+        server,
+        [
+            {
+                "name": "server.tool/bar",
+                "description": "Updated tool",
+                "schema": updated_schema,
+            }
+        ],
+    )
+
+    stmt = select(MCPServerTool).where(MCPServerTool.tool_name == "server.tool/bar")
+    result = await db_session.execute(stmt)
+    tool = result.scalar_one()
+
+    assert tool.tool_description == "Updated tool"
+    assert tool.tool_schema == updated_schema

--- a/tests/test_server_details.py
+++ b/tests/test_server_details.py
@@ -1,0 +1,79 @@
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from mcp_anywhere.auth.models import User
+from mcp_anywhere.database import MCPServer, MCPServerTool, get_async_session
+
+
+class _TimeoutManager:
+    def __init__(self):
+        self.calls = 0
+
+    def is_server_mounted(self, server_id: str) -> bool:
+        return True
+
+    async def get_runtime_tool(self, tool_key: str):
+        self.calls += 1
+        raise TimeoutError("timed out")
+
+
+async def _set_admin_password(app, password: str) -> None:
+    async with app.state.get_async_session() as session:
+        stmt = select(User).where(User.username == "admin")
+        user = await session.scalar(stmt)
+        assert user is not None
+        user.set_password(password)
+        session.add(user)
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_server_detail_uses_cached_schema_on_timeout(app, client):
+    async with get_async_session() as session:
+        server_name = f"Timeout Server {uuid.uuid4().hex[:6]}"
+        server = MCPServer(
+            name=server_name,
+            github_url="https://example.com/repo.git",
+            runtime_type="docker",
+            install_command="pip install -r requirements.txt",
+            start_command="uv run start",
+            env_variables=[],
+            is_active=True,
+            build_status="built",
+        )
+        session.add(server)
+        await session.flush()
+
+        tool = MCPServerTool(
+            server_id=server.id,
+            tool_name=f"{server_name}.tool/echo",
+            tool_description="Echo tool",
+            tool_schema={
+                "type": "object",
+                "properties": {"message": {"type": "string"}},
+            },
+            is_enabled=True,
+        )
+        session.add(tool)
+        await session.commit()
+
+        server_id = server.id
+
+    await _set_admin_password(app, "DetailPass123!")
+    login_response = await client.post(
+        "/auth/login",
+        data={"username": "admin", "password": "DetailPass123!"},
+        follow_redirects=False,
+    )
+    assert login_response.status_code == 302
+
+    timeout_manager = _TimeoutManager()
+    app.state.mcp_manager = timeout_manager
+
+    response = await client.get(f"/servers/{server_id}")
+    assert response.status_code == 200
+    assert "Tempo limite ao carregar as informações da ferramenta." in response.text
+    assert timeout_manager.calls == 1
+


### PR DESCRIPTION
## Summary
- persist MCP tool schemas during discovery so the web UI can reuse stored metadata
- add timeouts and graceful fallbacks when loading tool details and testing tools via the runtime
- cover the new behavior with tests for tool persistence and the server detail page timeout scenario

## Testing
- uv run python -m pytest tests/test_database_utils.py -q
- uv run python -m pytest tests/test_server_details.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e58d0b4e88832ea9c74df94cf5e861